### PR TITLE
Ensure Compatibility with Serial-UDP Bridge and Matlab Logger

### DIFF
--- a/src/clab_datalogger_receiver/serial_communication/_packetizers.py
+++ b/src/clab_datalogger_receiver/serial_communication/_packetizers.py
@@ -139,6 +139,11 @@ class TurtlebotThreadedConnection(SerialThreadedRecvTx):
     def signal_stop_communication(self):
         """Instruct the STM to start sendind data."""
         return self.send_data(self.STOP_DATA_TOKEN)
+    
+    def signal_send_communication_data_length(self, length: int):
+        """Signal the STM to send the data length."""
+        # to uint8  
+        return self.send_data(length.to_bytes(1, 'big'))
 
     def _validate_package(self, packet: bytes) -> Tuple[bool, bytes | None]:
         valid, data = super()._validate_package(packet)

--- a/src/clab_datalogger_receiver/serial_communication/communication.py
+++ b/src/clab_datalogger_receiver/serial_communication/communication.py
@@ -151,6 +151,8 @@ class ManualPortTurtlebotSerialConnector:
         assert isinstance(transport, TurtlebotReaderThread)
 
         self.__transport = transport
+        self.__protocol.signal_stop_communication()
+        self.__protocol.signal_send_communication_data_length(self.__packet_spec.get_struct_byte_size())
         self.__protocol.signal_start_communication()
         self.transport = self.__transport
 

--- a/src/clab_datalogger_receiver/udp_communication/types.py
+++ b/src/clab_datalogger_receiver/udp_communication/types.py
@@ -79,6 +79,16 @@ class UDPData:
                 return None
         # print(f"received from {addr} : {data}")
         # print(f"received : {data}")
+
+        # FIXME: The Matlab logger does not expect to have the null termination byte 
+        # Indeed the serial-UDP bridge on the TBOT strips it.
+        # On the other hand, this program expects it.
+        # To maintain compatibility with Matlab and the Serial-UDP bridge,
+        # we need to add here the null termination byte.
+        # We should evaluate to fix the Serial-UDP bridge and Matlab instead also to keep
+        # a consistent behavior between Serial and UDP.
+        if not data.endswith(b'\x00'):
+            data += b'\x00'
         return data
 
     @property


### PR DESCRIPTION
This PR improves compatibility between the datalogger receiver, the Serial-UDP bridge on the Turtlebot, and the Matlab-based logger by aligning expectations on message termination and synchronization signaling.

---

###  Changes

1. **UDP Communication (`UDPData.read`)**\
   Ensures that received UDP data ends with a null termination byte (`b'\x00'`).\
   This is necessary because:

   - The current Python receiver expects this null byte.
   - However, the Matlab logger does **not** expect it.
   - The Serial-to-UDP bridge on the Turtlebot strips the null byte before forwarding the data.

   To maintain compatibility across all systems, this logic now explicitly appends a null byte if it's not present.

   > ⚠️ **Note**: This is a workaround. In the future, the behavior should ideally be unified across all components (Matlab logger, Serial-UDP bridge, and Python receiver) to avoid such compensations at the application layer. **We should propose fixing the Serial-UDP bridge and Matlab instead**

2. **Serial Communication (`ManualPortTurtlebotSerialConnector.connect`)**

   - Added `signal_stop_communication()` before starting a new session.
   - Sends the packet size with `signal_send_communication_data_length(...)`.
   - Then calls `signal_start_communication()` to begin the session.

   This ensures that the receiver properly resets and re-synchronizes with the sender, mirroring the expected behavior of the Serial-UDP bridge.